### PR TITLE
remove -mtune and -fstrict-overflow params as gcc 4.1.2 doesn't like the...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BINPREFIX = $(PREFIX)/bin
 CUSTOMLIBPNG ?= ../libpng
 CUSTOMZLIB ?= ../zlib
 
-CFLAGSOPT ?= -O3 -mtune=native -fearly-inlining -fstrict-aliasing -ffast-math -funroll-loops -fstrict-overflow -fomit-frame-pointer -momit-leaf-frame-pointer -ffinite-math-only -fno-trapping-math -funsafe-loop-optimizations
+CFLAGSOPT ?= -O3 -fearly-inlining -fstrict-aliasing -ffast-math -funroll-loops -fomit-frame-pointer -momit-leaf-frame-pointer -ffinite-math-only -fno-trapping-math -funsafe-loop-optimizations
 
 CFLAGS ?= -DNDEBUG -Wall -Wno-unknown-pragmas -I. -I$(CUSTOMLIBPNG) -I$(CUSTOMZLIB) -I/usr/local/include/ -I/usr/include/ -I/usr/X11/include/ $(CFLAGSOPT)
 CFLAGS += -std=c99 $(CFLAGSADD)


### PR DESCRIPTION
I don't think you'll actually want to merge this, but I thought you might like to know that improved-pngquant builds on a 2006-era Redhat box (CentOS 5.8) with some minor GCC parameter tweaks.

I'm no autotools/Makefile wizard but I wondered if it is possible to degrade GCC parameters gracefully for older systems.

At any rate, keep up the good work :)
