### PR TITLE
undefined reference to symbol '__pow_finite@@GLIBC_2.15'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CFLAGS ?= -Wall -Wno-unknown-pragmas -I. -I$(CUSTOMLIBPNG) -I$(CUSTOMZLIB) -I/us
 CFLAGS += -std=c99 $(CFLAGSADD)
 
 LDFLAGS ?= -L$(CUSTOMLIBPNG) -L$(CUSTOMZLIB) -L/usr/local/lib/ -L/usr/lib/ -L/usr/X11/lib/
-LDFLAGS += -lpng -lz -lm lib/libimagequant.a $(LDFLAGSADD)
+LDFLAGS += -lpng -lz lib/libimagequant.a -lm $(LDFLAGSADD)
 
 OBJS = pngquant.o rwpng.o
 COCOA_OBJS = rwpng_cocoa.o


### PR DESCRIPTION
In some circumstances, libm does not appear to be linking to libimagequant.  By specifying -lm after libimagequant in the makefile, it's fixed.
