### PR TITLE
Fix subtle memory leak because of order of struct initialisation.

### DIFF
--- a/lib/pam.c
+++ b/lib/pam.c
@@ -164,8 +164,9 @@ LIQ_PRIVATE struct acolorhash_table *pam_allocacolorhash(unsigned int maxcolors,
     const unsigned int mempool_size = sizeof(struct acolorhash_table) + hash_size * sizeof(struct acolorhist_arr_head) + estimated_colors * sizeof(struct acolorhist_arr_item);
     struct acolorhash_table *t = mempool_create(&m, sizeof(*t), mempool_size, malloc, free);
     if (!t) return NULL;
+    void* buckets = mempool_alloc(&m, hash_size * sizeof(struct acolorhist_arr_head), 0);
     *t = (struct acolorhash_table){
-        .buckets = mempool_alloc(&m, hash_size * sizeof(struct acolorhist_arr_head), 0),
+        .buckets = buckets,
         .mempool = m,
         .hash_size = hash_size,
         .maxcolors = maxcolors,


### PR DESCRIPTION
Sometimes memory is lost in `acolorhash_table`. The reason appears to be that `mempool_alloc` is executed after the value of `m` has been assigned to the struct field `mempool`. This patch fixes the problem by forcing `mempool_alloc` to run first, updating `m` in the process.

Related output produced by valgrind:

```
==5101== 213,583 bytes in 1 blocks are definitely lost in loss record 2 of 7
==5101==    at 0x4C2CD7B: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5101==    by 0x413E34: mempool_create (mempool.c:29)
==5101==    by 0x413F7E: mempool_alloc (mempool.c:53)
==5101==    by 0x40FB68: pam_allocacolorhash (pam.c:168)
==5101==    by 0x40D83F: get_histogram (libimagequant.c:1019)
==5101==    by 0x40B0C1: liq_quantize_image (libimagequant.c:590)
==5101==    (...)
```
