### PR TITLE
Add getters to the library

### DIFF
--- a/lib/libimagequant.c
+++ b/lib/libimagequant.c
@@ -222,6 +222,7 @@ LIQ_EXPORT liq_error liq_get_quality(liq_attr* attr, int * minimum, int * target
     if (!CHECK_STRUCT_TYPE(attr, liq_attr)) return LIQ_INVALID_POINTER;
     * minimum = mse_to_quality (attr->max_mse);
     * target = mse_to_quality (attr->target_mse);
+    return LIQ_OK;
 }
 
 LIQ_EXPORT liq_error liq_set_max_colors(liq_attr* attr, int colors)

--- a/lib/libimagequant.h
+++ b/lib/libimagequant.h
@@ -53,10 +53,15 @@ LIQ_EXPORT liq_attr* liq_attr_copy(liq_attr *orig);
 LIQ_EXPORT void liq_attr_destroy(liq_attr *attr);
 
 LIQ_EXPORT liq_error liq_set_max_colors(liq_attr* attr, int colors);
+LIQ_EXPORT liq_error liq_get_max_colors(liq_attr* attr, int * colors);
 LIQ_EXPORT liq_error liq_set_speed(liq_attr* attr, int speed);
+LIQ_EXPORT liq_error liq_get_speed(liq_attr* attr, int * speed);
 LIQ_EXPORT liq_error liq_set_min_opacity(liq_attr* attr, int min);
+LIQ_EXPORT liq_error liq_get_min_opacity(liq_attr* attr, int *min);
 LIQ_EXPORT liq_error liq_set_min_posterization(liq_attr* attr, int bits);
+LIQ_EXPORT liq_error liq_get_min_posterization(liq_attr* attr, int *bits);
 LIQ_EXPORT liq_error liq_set_quality(liq_attr* attr, int minimum, int maximum);
+LIQ_EXPORT liq_error liq_get_quality(liq_attr* attr, int *minimum, int *maximum);
 LIQ_EXPORT void liq_set_last_index_transparent(liq_attr* attr, int is_last);
 
 typedef void liq_log_callback_function(const liq_attr*, const char *message, void* user_info);


### PR DESCRIPTION
Writing from another programming language (Perl in my case), it's a bit of a help to have a getter so that the parameters set can be extracted again from the object. I added these getter functions for my library, I am issuing a pull request because I think they are useful for other programmers writing against the library too. This also alters the structure of liq_attr to add a field speed since it was a lot of work to extract it back again from the other parameters.

If you agree to this pull request I'll also add documentation.
