### PR TITLE
Change code to make it compatible with Microsoft Visual C 18.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ DerivedData
 pngquant
 build_configuration
 lib/libimagequant.a
+*.obj
+*.lib

--- a/lib/Makefile.mak
+++ b/lib/Makefile.mak
@@ -1,0 +1,25 @@
+!if "$(PLATFORM)" == "X64"
+MACHINE=X64
+!else
+MACHINE=X86
+!endif
+
+!ifndef USE_SSE
+USE_SSE=1
+!endif
+
+CFLAGS = /Ox /GL /MD /nologo /DNDEBUG /DUSE_SSE=$(USE_SSE)
+LINKFLAGS = /LTCG /nologo
+OBJECTS = blur.obj libimagequant.obj mediancut.obj mempool.obj nearest.obj pam.obj viter.obj
+
+.c.obj:
+	$(CC) $(CFLAGS) /c $<
+
+all: libimagequant.lib
+
+libimagequant.lib : $(OBJECTS)
+	lib /machine:$(MACHINE) /out:$@ $(LINKFLAGS) $**
+
+clean:
+	del *.obj
+	del *.lib

--- a/lib/pam.c
+++ b/lib/pam.c
@@ -46,7 +46,8 @@ LIQ_PRIVATE bool pam_computeacolorhash(struct acolorhash_table *acht, const rgba
             }
 
             // RGBA color is casted to long for easier hasing/comparisons
-            union rgba_as_int px = {pixels[row][col]};
+            const rgba_pixel tmp = pixels[row][col];
+            union rgba_as_int px = {{tmp.r, tmp.g, tmp.b, tmp.a}};
             unsigned int hash;
             if (!px.rgba.a) {
                 // "dirty alpha" has different RGBA values that end up being the same fully transparent color
@@ -85,7 +86,7 @@ LIQ_PRIVATE bool pam_computeacolorhash(struct acolorhash_table *acht, const rgba
                     // the array was allocated with spare items
                     if (i < achl->capacity) {
                         other_items[i] = (struct acolorhist_arr_item){
-                            .color = px,
+                            .color = {{px.rgba.r, px.rgba.g, px.rgba.b, px.rgba.a}},
                             .perceptual_weight = boost,
                         };
                         achl->used++;
@@ -127,7 +128,7 @@ LIQ_PRIVATE bool pam_computeacolorhash(struct acolorhash_table *acht, const rgba
                     achl->other_items = new_items;
                     achl->capacity = capacity;
                     new_items[i] = (struct acolorhist_arr_item){
-                        .color = px,
+                        .color = {{px.rgba.r, px.rgba.g, px.rgba.b, px.rgba.a}},
                         .perceptual_weight = boost,
                     };
                     achl->used++;

--- a/lib/viter.c
+++ b/lib/viter.c
@@ -62,7 +62,8 @@ LIQ_PRIVATE void viter_finalize(colormap *map, const unsigned int max_threads, c
 LIQ_PRIVATE double viter_do_iteration(histogram *hist, colormap *const map, const float min_opaque_val, viter_callback callback, const bool fast_palette)
 {
     const unsigned int max_threads = omp_get_max_threads();
-    viter_state average_color[(VITER_CACHE_LINE_GAP+map->colors) * max_threads];
+    viter_state *average_color = malloc((VITER_CACHE_LINE_GAP+map->colors) * max_threads * sizeof(viter_state));
+    assert(average_color != NULL);
     viter_init(map, max_threads, average_color);
     struct nearest_map *const n = nearest_init(map, fast_palette);
     hist_item *const achv = hist->achv;
@@ -85,5 +86,6 @@ LIQ_PRIVATE double viter_do_iteration(histogram *hist, colormap *const map, cons
     nearest_free(n);
     viter_finalize(map, max_threads, average_color);
 
+    free(average_color);
     return total_diff / hist->total_perceptual_weight;
 }


### PR DESCRIPTION
Changes needed for MSVC 18.0 (Visual Studio 12.0 or Visual Studio 2013)

MSVC only compiles C89 and some C99 features sometimes using own syntax. E.g.declaring variables after code and using __restrict instead of restrict. With some minor changes the libpngquant code can be made compatible with Microsoft Visual Studio 2013. The changes are the following:

1. MSVC does not have the inline keyword. Where GCC uses attributes to specify no inline or force inlining, MSVC uses different attributes.
   Change is to define three macro definitions:
     - INLINE
     - NO_INLINE
     - FORCE_INLINE
   and set it correctly to inline and a GCC attribute or a MSVC attribute depending on compiler. And use it instead of inline.

2. MSVC does not support the restrict keyword, but has a __restrict attribute.
   Change is to define a macro definition restrict as __restrict when compiling with MSVC.

3. MSVC does not support variable length arrays.
   Change is to use malloc and free instead.

4. MSVC does not support AT&T asm syntax. This is used for detecting SSE.
   We use the Microsoft __cpuid function to get the same information.

5. Declaring variables after an if/for/while statement without braces is not allowed in MSVC.
    Change is to use braces in these cases.

6. MSVC uses a different way of aligning structures in memory: __declspec(align(16)). When using the MSVC way, it is not possible to pass the f_pixel variables by value. Since this is used a lot we chose to use an unaligned load. Due to some strange way of optimizing a volatile keyword is necessary to prevent crashes.

7. Assertion of aligned memory does not work.
    Change is to disable the assertion in MSVC (libimagequant.c:602)