### PR TITLE
Avoid single colours to dominate the quality calculation

### DIFF
--- a/lib/pam.h
+++ b/lib/pam.h
@@ -258,7 +258,7 @@ struct acolorhist_arr_head {
 
 struct acolorhash_table {
     struct mempool *mempool;
-    unsigned int ignorebits, maxcolors, colors, rows;
+    unsigned int ignorebits, maxcolors, colors, cols, rows;
     unsigned int hash_size;
     unsigned int freestackp;
     struct acolorhist_arr_item *freestack[512];


### PR DESCRIPTION
There appears to be a quality issue for images with large amount of solid colours or a transparent background. The exact match with the single background colour dominates the quality calculation, causing too few colours to be used for the primary subject.

Take this image for example, a bunny on a large white background:

![bunny](https://cloud.githubusercontent.com/assets/78237/2959994/15eeee6c-dab8-11e3-9856-d07b51fcebdc.png)

When processed with `pngquant --quality 95 --speed 1` the bunny itself is rendered with very few colours. Too few to justify a quality of 95. Here is an enlarged cutout of the original and the processed version:

![bunny-cutout-orig](https://cloud.githubusercontent.com/assets/78237/2960012/46bbdfc8-dab8-11e3-91bf-2d8c948208a4.png)
![bunny-cutout-old](https://cloud.githubusercontent.com/assets/78237/2960016/4b766696-dab8-11e3-89a2-a5c4ff89ae36.png)

This PR is an attempt to fix it. Here is a cutout of the result of the same command with this commit applied:

![bunny-cutout-new](https://cloud.githubusercontent.com/assets/78237/2960114/530012bc-dab9-11e3-9c1d-9e6fdcf21966.png)

This PR makes sure that the `perceptual_weight` of a single colour will not exceed ~10% of the image. It works as expected for the type of images like this bunny image. It also introduces very little different behaviour in other kinds of images, as far as I have been able to detect.

(It does not improve the situation where a very slight, nearly invisible gradient is overlaid over a solid background colour, since that causes no exact single colour to be used in more than 10% of the image. But that's probably a very synthetic situation.)
