### PR TITLE
[RFC] libimagequant: Allow building as a shared library on UNIX

### DIFF
--- a/lib/configure
+++ b/lib/configure
@@ -116,7 +116,6 @@ status "Compiler" "$CC"
 # init flags
 CFLAGS=${CFLAGS:--O3 -fno-math-errno -funroll-loops -fomit-frame-pointer -Wall}
 cflags "-std=c99 -I."
-lflags "-lm lib/libimagequant.a"
 
 # DEBUG
 if [ -z "$DEBUG" ]; then


### PR DESCRIPTION
Makes it a lot easier to call from other languages.

This is kind of messy, and if you prefer I merge it with the DLL generation (and maybe dylib too?), I will do that.