### PR TITLE
Don't link the static lib into the shared lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ $(OBJS): $(wildcard *.h) config.mk
 rwpng_cocoa.o: rwpng_cocoa.m
 	$(CC) -Wno-enum-conversion -c $(CFLAGS) -o $@ $< || clang -Wno-enum-conversion -c -O3 $(CFLAGS) -o $@ $<
 
-$(BIN): $(STATICLIB) $(OBJS)
-	$(CC) $(OBJS) $(LDFLAGS) -o $@
+$(BIN): $(OBJS) $(STATICLIB)
+	$(CC) $^ $(LDFLAGS) -o $@
 
 dist: $(TARFILE)
 

--- a/configure
+++ b/configure
@@ -230,7 +230,6 @@ status "Compiler" "$CC"
 # init flags
 CFLAGS=${CFLAGS:--O3 -fno-math-errno -funroll-loops -fomit-frame-pointer -Wall}
 cflags "-std=c99 -I."
-lflags "-lm lib/libimagequant.a"
 
 # DEBUG
 if [ -z "$DEBUG" ]; then

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -27,7 +27,7 @@ dll:
 
 
 $(DLL) $(DLLIMP): $(OBJS)
-	$(CC) -fPIC -shared -o $(DLL) $(OBJS) $(LDFLAGS) -Wl,--out-implib,$(DLLIMP),--output-def,$(DLLDEF)
+	$(CC) -fPIC -shared -o $(DLL) $^ $(LDFLAGS) -Wl,--out-implib,$(DLLIMP),--output-def,$(DLLDEF)
 
 $(STATICLIB): $(OBJS)
 	$(AR) $(ARFLAGS) $@ $^
@@ -36,7 +36,7 @@ $(SHAREDOBJS):
 	$(CC) -fPIC $(CFLAGS) -c $(@:.lo=.c) -o $@
 
 $(SHAREDLIB): $(SHAREDOBJS)
-	$(CC) -shared -o $(SHAREDLIB) $(SHAREDOBJS) $(LDFLAGS)
+	$(CC) -shared -o $@ $^ $(LDFLAGS)
 
 $(OBJS): $(wildcard *.h) config.mk
 


### PR DESCRIPTION
```
make -C lib shared
...
gcc -shared -o libimagequant.so.0 pam.lo mediancut.lo blur.lo mempool.lo viter.lo nearest.lo libimagequant.lo -lm lib/libimagequant.a -lpng14   -lz   -llcms2   -lm
gcc: error: lib/libimagequant.a: No such file or directory
make: *** [libimagequant.so.0] Error 1
```
The static lib doesn't exist because I haven't built it.  But it's not needed here, definitely shouldn't be linked into the shared lib.