### PR TITLE
Give warning instead stop with error when not recognize the option

### DIFF
--- a/configure
+++ b/configure
@@ -102,8 +102,7 @@ fi
         EXTRA_LDFLAGS="$EXTRA_LDFLAGS ${i#*=}"
         ;;
     *)
-        echo "error: unknown switch ${i%%=*} (see $0 --help for the list)"
-        exit 1
+        echo "warning: unknown switch ${i%%=*} (see $0 --help for the list)"
         ;;
     esac
 done


### PR DESCRIPTION
This is useful for packaging on
Fedora/RedHat. If configure just warning, we can run %configure macro, which is
must better.