### PR TITLE
Add soname for shared lib and rules in main file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ OBJS += $(COCOA_OBJS)
 endif
 
 STATICLIB = lib/libimagequant.a
+SHAREDLIB = lib/libimagequant.so
 
 DISTFILES = *.[chm] pngquant.1 Makefile configure README.md INSTALL CHANGELOG COPYRIGHT
 TARNAME = pngquant-$(VERSION)
@@ -31,6 +32,11 @@ staticlib:
 	$(MAKE) -C lib static
 
 $(STATICLIB): config.mk staticlib
+
+sharedlib:
+	$(MAKE) -C lib shared
+
+$(SHAREDLIB): config.mk sharedlib
 
 $(OBJS): $(wildcard *.h) config.mk
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,7 +1,8 @@
 -include config.mk
 
 STATICLIB=libimagequant.a
-SHAREDLIB=libimagequant.so.0
+SHAREDLIB=libimagequant.so
+SOVER=0
 
 DLL=libimagequant.dll
 DLLIMP=libimagequant_dll.a
@@ -34,7 +35,8 @@ $(SHAREDOBJS):
 	$(CC) -fPIC $(CFLAGS) -c $(@:.lo=.c) -o $@
 
 $(SHAREDLIB): $(SHAREDOBJS)
-	$(CC) -shared -o $@ $^ $(LDFLAGS)
+	$(CC) -shared -Wl,-soname,$(SHAREDLIB).$(SOVER) -o $(SHAREDLIB).$(SOVER) $^ $(LDFLAGS)
+	ln -fs $(SHAREDLIB).$(SOVER) $(SHAREDLIB)
 
 $(OBJS): $(wildcard *.h) config.mk
 
@@ -49,7 +51,7 @@ $(TARFILE): $(DISTFILES)
 	-shasum $(TARFILE)
 
 clean:
-	rm -f $(OBJS) $(SHAREDOBJS) $(SHAREDLIB) $(STATICLIB) $(TARFILE) $(DLL) $(DLLIMP) $(DLLDEF)
+	rm -f $(OBJS) $(SHAREDOBJS) $(SHAREDLIB).$(SOVER) $(SHAREDLIB) $(STATICLIB) $(TARFILE) $(DLL) $(DLLIMP) $(DLLDEF)
 
 distclean: clean
 	rm -f config.mk


### PR DESCRIPTION
In Fedora / RedHat we use shared lib  , our patch have one more line [1] but I just send the part that not change the logic of default. 

[1]

    -$(BIN): $(OBJS) $(STATICLIB)
    +$(BIN): $(OBJS) $(SHAREDLIB)
        $(CC) $^ $(CFLAGS) $(LDFLAGS) -o $@
