### PR TITLE
Refer new libpng16-dev package in error message

### DIFF
--- a/configure
+++ b/configure
@@ -388,7 +388,7 @@ if [ "$SUCCESS" -eq 0 ]; then
     if [[ "$OSTYPE" =~ "darwin" ]]; then
         LIBPNG_CMD='`brew install libpng`'
     else
-        LIBPNG_CMD='`apt-get install libpng-dev` or `yum install libpng-devel`'
+        LIBPNG_CMD='`apt-get install libpng16-dev` or `apt-get install libpng-dev` or `yum install libpng-devel`'
     fi
     error "libpng" "not found (try: $LIBPNG_CMD)"
 fi


### PR DESCRIPTION
Ubuntu 16.04 adds a new [libpng16-dev](http://packages.ubuntu.com/search?keywords=libpng16-dev) package, which pngquant prefers to be compiled against. This PR updates the error message to refer to libpng16-dev.

libpng-dev and libpng16-dev both work, but with libpng-dev we get the following warning:

```
WARNING: Your version of libpng is outdated and may produce corrupted files.
Please recompile pngquant with the current version of libpng (1.6 or later).
```

I'm still preserving `apt-get install libpng-dev` for the benefit of people on older Ubuntu/Debian systems.