### PR TITLE
Do not under-weigh colordifference for transparent pixels

### DIFF
--- a/lib/libimagequant.c
+++ b/lib/libimagequant.c
@@ -1611,7 +1611,7 @@ static colormap *find_best_palette(histogram *hist, const liq_attr *options, con
     do {
         colormap *newmap;
         if (hist->size && fixed_colors_count < max_colors) {
-            newmap = mediancut(hist, max_colors-fixed_colors_count, target_mse * target_mse_overshoot, MAX(MAX(90.0/65536.0, target_mse), least_error)*1.2,
+            newmap = mediancut(hist, max_colors-fixed_colors_count, target_mse * target_mse_overshoot, MAX(MAX(45.0/65536.0, target_mse), least_error)*1.2,
             options->malloc, options->free);
         } else {
             feedback_loop_trials = 0;

--- a/lib/mediancut.c
+++ b/lib/mediancut.c
@@ -279,7 +279,7 @@ inline static double color_weight(f_pixel median, hist_item h)
 {
     float diff = colordifference(median, h.acolor);
     // if color is "good enough", don't split further
-    if (diff < 2.f/256.f/256.f) diff /= 2.f;
+    if (diff < 1.f/256.f/256.f) diff /= 2.f;
     return sqrt(diff) * (sqrt(1.0+h.adjusted_weight)-1.0);
 }
 
@@ -444,7 +444,7 @@ static void adjust_histogram(hist_item *achv, const colormap *map, const struct 
 {
     for(unsigned int bi = 0; bi < boxes; ++bi) {
         for(unsigned int i=bv[bi].ind; i < bv[bi].ind+bv[bi].colors; i++) {
-            achv[i].adjusted_weight *= sqrt(1.0 +colordifference(map->palette[bi].acolor, achv[i].acolor)/4.0);
+            achv[i].adjusted_weight *= sqrt(1.0 +colordifference(map->palette[bi].acolor, achv[i].acolor)/2.0);
             achv[i].tmp.likely_colormap_index = bi;
         }
     }

--- a/lib/pam.h
+++ b/lib/pam.h
@@ -141,7 +141,7 @@ inline static double colordifference_ch(const double x, const double y, const do
     // maximum of channel blended on white, and blended on black
     // premultiplied alpha and backgrounds 0/1 shorten the formula
     const double black = x-y, white = black+alphas;
-    return black*black + white*white;
+    return MAX(black*black, white*white);
 }
 
 ALWAYS_INLINE static float colordifference_stdc(const f_pixel px, const f_pixel py);
@@ -182,7 +182,7 @@ inline static float colordifference(f_pixel px, f_pixel py)
 
     onblack = _mm_mul_ps(onblack, onblack);
     onwhite = _mm_mul_ps(onwhite, onwhite);
-    const __m128 max = _mm_add_ps(onwhite, onblack);
+    const __m128 max = _mm_max_ps(onwhite, onblack);
 
     // add rgb, not a
     const __m128 maxhl = _mm_movehl_ps(max, max);


### PR DESCRIPTION
This reverts 89929a806743f6e12fac25ed2c6433f1fe112284.

-----------

I'm not sure whether this should be merged - see #199 for discussion.