### PR TITLE
Fix loop variables for OpenMP with MSVC

### DIFF
--- a/lib/libimagequant.c
+++ b/lib/libimagequant.c
@@ -1090,6 +1090,7 @@ LIQ_NONNULL static float remap_to_palette(liq_image *const input_image, unsigned
     const int rows = input_image->height;
     const unsigned int cols = input_image->width;
     double remapping_error=0;
+    int row;
 
     if (!liq_image_get_row_f(input_image, 0)) { // trigger lazy conversion
         return -1;
@@ -1106,7 +1107,7 @@ LIQ_NONNULL static float remap_to_palette(liq_image *const input_image, unsigned
 
     #pragma omp parallel for if (rows*cols > 3000) \
         schedule(static) default(none) shared(average_color) reduction(+:remapping_error)
-    for(int row = 0; row < rows; ++row) {
+    for(row = 0; row < rows; ++row) {
         const f_pixel *const row_pixels = liq_image_get_row_f(input_image, row);
         unsigned int last_match=0;
         for(unsigned int col = 0; col < cols; ++col) {

--- a/lib/viter.c
+++ b/lib/viter.c
@@ -87,11 +87,12 @@ LIQ_PRIVATE double viter_do_iteration(histogram *hist, colormap *const map, vite
     struct nearest_map *const n = nearest_init(map, fast_palette);
     hist_item *const achv = hist->achv;
     const int hist_size = hist->size;
+    int j;
 
     double total_diff=0;
     #pragma omp parallel for if (hist_size > 3000) \
         schedule(static) default(none) shared(average_color,callback) reduction(+:total_diff)
-    for(int j=0; j < hist_size; j++) {
+    for(j=0; j < hist_size; j++) {
         float diff;
         unsigned int match = nearest_search(n, &achv[j].acolor, achv[j].tmp.likely_colormap_index, &diff);
         achv[j].tmp.likely_colormap_index = match;

--- a/rwpng.c
+++ b/rwpng.c
@@ -383,6 +383,7 @@ static pngquant_error rwpng_read_image24_libpng(FILE *infile, png24_image *mainp
 
     /* transform image to sRGB colorspace */
     if (hInProfile != NULL) {
+        long i;
 
         cmsHPROFILE hOutProfile = cmsCreate_sRGBProfile();
         cmsHTRANSFORM hTransform = cmsCreateTransform(hInProfile, TYPE_RGBA_8,
@@ -393,7 +394,7 @@ static pngquant_error rwpng_read_image24_libpng(FILE *infile, png24_image *mainp
         #pragma omp parallel for \
             if (mainprog_ptr->height*mainprog_ptr->width > 8000) \
             schedule(static)
-        for (unsigned int i = 0; i < mainprog_ptr->height; i++) {
+        for (i = 0; i < mainprog_ptr->height; i++) {
             /* It is safe to use the same block for input and output,
                when both are of the same TYPE. */
             cmsDoTransform(hTransform, row_pointers[i],


### PR DESCRIPTION
Apparently MSVC does not allow declaring variables in OpenMP loops.