### PR TITLE
ignore chunks with 0 location

### DIFF
--- a/rwpng.c
+++ b/rwpng.c
@@ -159,6 +159,10 @@ static int read_chunk_callback(png_structp png_ptr, png_unknown_chunkp in_chunk)
         return 0; // not handled
     }
 
+    if (in_chunk->location == 0 ) {
+        return 1; // ignore chunks with invalid location
+    }
+
     struct rwpng_chunk **head = (struct rwpng_chunk **)png_get_user_chunk_ptr(png_ptr);
 
     struct rwpng_chunk *chunk = malloc(sizeof(struct rwpng_chunk));


### PR DESCRIPTION
If a chunk has it's location set to 0 it causes a segmentation fault it in rwpng_write_image8().
$ ./pngquant crash02.png 
libpng warning: png_set_unknown_chunks now expects a valid location
  error: invalid location in png_set_unknown_chunks (libpng failed)
Segmentation fault (core dumped)

Ignoring chunks with the location set to 0 fixes the issue.

The issue can be reproduced with the attached PNG.
![crash02](https://cloud.githubusercontent.com/assets/11544375/20410033/7dc45418-ad1b-11e6-9137-1f7193a35fa6.png)
https://cloud.githubusercontent.com/assets/11544375/20410033/7dc45418-ad1b-11e6-9137-1f7193a35fa6.png

