### PR TITLE
Missing space in if statement

### DIFF
--- a/configure
+++ b/configure
@@ -374,7 +374,7 @@ if [ "$HAS_LIBPNG" -eq 0 ]; then
         PNGH_MAJMIN=$(pngh_majmin "$PNGH")
         if [[ -n "$PNGH_STRING" && -n "$PNGH_MAJMIN" ]]; then
             LIBPNGA=$(find_f "$LIBPNG_DIR" "libpng${PNGH_MAJMIN}.a")
-            if [ -z "$LIBPNGA"]; then
+            if [ -z "$LIBPNGA" ]; then
                 LIBPNGA=$(find_f "$LIBPNG_DIR" "libpng.a")
             fi
             if [ -n "$LIBPNGA" ]; then


### PR DESCRIPTION
./configure --with-openmp --with-lcms2 --with-libpng=../libpng-1.6.28

Result:

  Compiler: gcc
     Debug: no
       SSE: yes
    OpenMP: yes
./configure: line 377: [: missing `]'
    libpng: static (1.6.28)
      zlib: shared (1.2.7)
     lcms2: shared (2.6)