### PR TITLE
Ability to write to stdout when passing a file

### DIFF
--- a/pngquant.c
+++ b/pngquant.c
@@ -335,7 +335,7 @@ int main(int argc, char *argv[])
                     fputs("--output option can be used only once\n", stderr);
                     return INVALID_ARGUMENT;
                 }
-                if (strncmp(optarg, "-", 1) == 0) {
+                if (strcmp(optarg, "-") == 0) {
                     options.using_stdout = true;
                     break;
                 }

--- a/pngquant.c
+++ b/pngquant.c
@@ -60,6 +60,8 @@ Quantizes one or more 32-bit RGBA PNGs to 8-bit (or smaller) RGBA-palette.\n\
 The output filename is the same as the input name except that\n\
 it ends in \"-fs8.png\", \"-or8.png\" or your custom extension (unless the\n\
 input is stdin, in which case the quantized image will go to stdout).\n\
+If you pass the special output path \"-\" and a single input file, that file\n\
+will be processed and the quantized image will go to stdout.\n\
 The default behavior if the output file exists is to skip the conversion;\n\
 use --force to overwrite. See man page for full list of options.\n"
 
@@ -333,6 +335,10 @@ int main(int argc, char *argv[])
                     fputs("--output option can be used only once\n", stderr);
                     return INVALID_ARGUMENT;
                 }
+                if (strncmp(optarg, "-", 1) == 0) {
+                    options.using_stdout = true;
+                    break;
+                }
                 output_file_path = optarg; break;
 
             case arg_iebug:
@@ -470,6 +476,10 @@ int main(int argc, char *argv[])
 
     if (output_file_path && num_files != 1) {
         fputs("Only one input file is allowed when --output is used\n", stderr);
+        return INVALID_ARGUMENT;
+    }
+    if (options.using_stdout && !options.using_stdin && num_files != 1) {
+        fputs("Only one input file is allowed when using the special output path \"-\" to write to stdout\n", stderr);
         return INVALID_ARGUMENT;
     }
 


### PR DESCRIPTION
Modifies the CLI to permit passing the special output path “-“, which causes the input file to be processed to `stdout` instead of written to a specific output path. 

This makes PNGQuant match the behavior of JPEGOptim and makes integration into tools easier. (There are some edge cases that make it tricky to reliably feed input over `stdin` to a subprocess running under a Mac application, so I'd rather toss the file-reading responsibility to PNGQuant and just have it send me back data over `stdout` that my app can then do stuff with.)

I believe I've covered the edge cases, including limiting the number of input files to 1 when using this new feature and modifying the help instructions, but you'll want to double-check because I'm not familiar with the code base.