### PR TITLE
Fix warnings reported by hardened compiler flags

### DIFF
--- a/pngquant.c
+++ b/pngquant.c
@@ -75,9 +75,6 @@ use --force to overwrite. See man page for full list of options.\n"
 #include <unistd.h>
 #include <math.h>
 
-extern char *optarg;
-extern int optind, opterr;
-
 #if defined(WIN32) || defined(__WIN32__)
 #  include <fcntl.h>    /* O_BINARY */
 #  include <io.h>   /* setmode() */
@@ -131,6 +128,8 @@ static void verbose_printf(struct pngquant_options *context, const char *fmt, ..
 
 static void log_callback(const liq_attr *attr, const char *msg, void* user_info)
 {
+    (void)(attr);
+    (void)(user_info);
     fprintf(stderr, "%s\n", msg);
 }
 
@@ -730,6 +729,8 @@ static void set_binary_mode(FILE *fp)
 {
 #if defined(WIN32) || defined(__WIN32__)
     setmode(fp == stdout ? 1 : 0, O_BINARY);
+#else
+    (void)(fp);
 #endif
 }
 
@@ -749,6 +750,8 @@ static bool replace_file(const char *from, const char *to, const bool force) {
         // On Windows rename doesn't replace
         unlink(to);
     }
+#else
+    (void)(force);
 #endif
     return (0 == rename(from, to));
 }

--- a/rwpng.c
+++ b/rwpng.c
@@ -132,6 +132,7 @@ static void user_write_data(png_structp png_ptr, png_bytep data, png_size_t leng
 
 static void user_flush_data(png_structp png_ptr)
 {
+    (void)(png_ptr);
     // libpng never calls this :(
 }
 
@@ -193,10 +194,13 @@ static int read_chunk_callback(png_structp png_ptr, png_unknown_chunkp in_chunk)
 
 #if !USE_COCOA
 static void rwpng_warning_stderr_handler(png_structp png_ptr, png_const_charp msg) {
+    (void)(png_ptr);
     fprintf(stderr, "  libpng warning: %s\n", msg);
 }
 
 static void rwpng_warning_silent_handler(png_structp png_ptr, png_const_charp msg) {
+    (void)(png_ptr);
+    (void)(msg);
 }
 
 static pngquant_error rwpng_read_image24_libpng(FILE *infile, png24_image *mainprog_ptr, int strip, int verbose)
@@ -249,7 +253,7 @@ static pngquant_error rwpng_read_image24_libpng(FILE *infile, png24_image *mainp
      * etc., but want bit_depth and color_type for later [don't care about
      * compression_type and filter_type => NULLs] */
 
-    png_get_IHDR(png_ptr, info_ptr, &mainprog_ptr->width, &mainprog_ptr->height,
+    png_get_IHDR(png_ptr, info_ptr, (png_uint_32 *)&mainprog_ptr->width, (png_uint_32 *)&mainprog_ptr->height,
                  &bit_depth, &color_type, NULL, NULL, NULL);
 
     /* expand palette images to RGB, low-bit-depth grayscale images to 8 bits,


### PR DESCRIPTION
Just a few small sign warnings that can be casted away. Found with the following flags:

`-W -Wall -Wextra -Wunused-function -Werror=write-strings -Werror=redundant-decls -Werror=format -Werror=format-security -Werror=declaration-after-statement -Werror=implicit-function-declaration -Werror=date-time -Werror=missing-prototypes -Werror=return-type -Werror=pointer-arith -Winit-self`