### PR TITLE
check if the SUCCESS is defined

### DIFF
--- a/rwpng.h
+++ b/rwpng.h
@@ -45,7 +45,9 @@
 #endif
 
 typedef enum {
+#ifndef SUCCESS
     SUCCESS = 0,
+#endif
     MISSING_ARGUMENT = 1,
     READ_ERROR = 2,
     INVALID_ARGUMENT = 4,


### PR DESCRIPTION
according to my other PR #267 , and since `SUCCESS` is a popular enum that used widely, I think that we need to check whether this is pre-defined or not.